### PR TITLE
chore: force approval for vulnerability alerts

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -8,6 +8,9 @@
 		":widenPeerDependencies",
 		"group:allNonMajor"
 	],
+	"vulnerabilityAlerts": {
+		"dependencyDashboardApproval": true
+	},
 	"assigneesFromCodeOwners": true,
 	"commitMessagePrefix": "[Deps] Update ",
 	"commitMessageTopic": "`{{depName}}`",


### PR DESCRIPTION
Overrides Renovate's default behavior, which is to bypass dependency dashboard approval for vulnerability alerts.